### PR TITLE
Add circular buffer windowed max problem and solution

### DIFF
--- a/notes/circular_buffer_windowed_max_notes.txt
+++ b/notes/circular_buffer_windowed_max_notes.txt
@@ -1,0 +1,14 @@
+Circular Buffer with Windowed Max Notes
+======================================
+
+This implementation maintains a ring buffer of fixed size. Each slot is
+initialized to `INT_MIN` so that unused entries do not affect the
+computed maximum. The index `head` always points to the next location to
+write. After inserting a reading, `head` advances with wraparound using
+`(head + 1) % size`.
+
+`get_max_last_k` walks backwards from the most recent element and scans
+at most `window` positions to compute the maximum. Because unused
+positions contain `INT_MIN`, they are ignored naturally when the buffer
+is not yet full. This approach avoids dynamic memory entirely and
+operates in O(K) time.

--- a/problems/circular_buffer_windowed_max.c
+++ b/problems/circular_buffer_windowed_max.c
@@ -1,0 +1,31 @@
+/*
+ * Problem: Circular Buffer with Windowed Max
+ * -----------------------------------------
+ * Implement a fixed-size circular buffer for sensor readings.
+ * After each insertion, return the maximum value among the last K readings.
+ * No dynamic memory is allowed; use only preallocated static arrays.
+ *
+ * Types and Functions:
+ *   #define MAX_N 1024
+ *   typedef struct {
+ *       int buffer[MAX_N];
+ *       int head;      // index for next insert
+ *       int size;      // total buffer capacity (<= MAX_N)
+ *       int window;    // K - number of last readings to consider (<= size)
+ *   } CircularSensorBuffer;
+ *
+ *   void init_buffer(CircularSensorBuffer *cb, int size, int window);
+ *       - Initialize the circular buffer with given size and window.
+ *   void insert_reading(CircularSensorBuffer *cb, int value);
+ *       - Insert a reading, overwriting the oldest when full.
+ *   int get_max_last_k(CircularSensorBuffer *cb);
+ *       - Return the maximum value among the most recent 'window' readings.
+ *
+ * Requirements:
+ *   - Circular insertion using (head + 1) % size.
+ *   - get_max_last_k must run in O(K) time or better.
+ *   - No dynamic memory allocation.
+ *
+ * Optional Challenge:
+ *   Implement get_max_last_k in amortized O(1) using a monotonic deque.
+ */

--- a/solutions/circular_buffer_windowed_max.c
+++ b/solutions/circular_buffer_windowed_max.c
@@ -1,0 +1,47 @@
+#include <limits.h>
+
+#define MAX_N 1024
+
+typedef struct {
+    int buffer[MAX_N];
+    int head;
+    int size;
+    int window;
+} CircularSensorBuffer;
+
+/* Initialize the circular buffer */
+void init_buffer(CircularSensorBuffer *cb, int size, int window)
+{
+    if (size > MAX_N)
+        size = MAX_N;
+    if (window > size)
+        window = size;
+
+    cb->size = size;
+    cb->window = window;
+    cb->head = 0;
+
+    for (int i = 0; i < size; ++i) {
+        cb->buffer[i] = INT_MIN; /* mark as empty */
+    }
+}
+
+/* Insert a reading and overwrite oldest when full */
+void insert_reading(CircularSensorBuffer *cb, int value)
+{
+    cb->buffer[cb->head] = value;
+    cb->head = (cb->head + 1) % cb->size;
+}
+
+/* Return maximum among the last 'window' readings */
+int get_max_last_k(CircularSensorBuffer *cb)
+{
+    int max_val = INT_MIN;
+    for (int i = 0; i < cb->window; ++i) {
+        int idx = (cb->head - 1 - i + cb->size) % cb->size;
+        if (cb->buffer[idx] > max_val) {
+            max_val = cb->buffer[idx];
+        }
+    }
+    return max_val;
+}


### PR DESCRIPTION
## Summary
- add new problem statement for circular buffer windowed max
- document implementation notes
- provide embedded C solution

## Testing
- `gcc -std=c99 -Wall -Wextra -pedantic -c solutions/circular_buffer_windowed_max.c -o /tmp/test.o`

------
https://chatgpt.com/codex/tasks/task_e_6885aee534fc83319867bce8acee1f27