### PR TITLE
Add memory efficient frequency tracker problem

### DIFF
--- a/notes/memory_efficient_frequency_tracker_notes.txt
+++ b/notes/memory_efficient_frequency_tracker_notes.txt
@@ -1,0 +1,19 @@
+Memory-Efficient Frequency Tracker Notes
+=======================================
+
+The frequency table stores two 4-bit counters per byte to track the
+occurrence count of all 256 possible sensor values.
+
+- **Byte layout**: index `i` corresponds to byte `i/2`.
+  - If `i` is even, its count occupies the lower 4 bits.
+  - If `i` is odd, the count is in the upper 4 bits.
+
+- **Incrementing**: read the existing 4-bit value, clamp it to a maximum
+  of 15, then store it back by masking and shifting. This avoids
+  exceeding the 4-bit limit.
+
+- **Helper** `get_frequency` simply extracts the proper nibble and
+  returns it, aiding code readability.
+
+This compact representation requires only 128 bytes, well under the
+512-byte limit, while still supporting up to 15 occurrences per value.

--- a/problems/memory_efficient_frequency_tracker.c
+++ b/problems/memory_efficient_frequency_tracker.c
@@ -1,0 +1,19 @@
+/*
+ * Problem: Memory-Efficient Frequency Tracker for 8-bit Values
+ * -----------------------------------------------------------
+ * We need to count how many times each 8-bit reading (0-255) occurs
+ * using no more than 512 bytes for the frequency table. Each count can
+ * be at most 15, so we pack two 4-bit counters into one byte.
+ *
+ * Implement:
+ *   void track_frequencies(uint8_t readings[], int size,
+ *                          uint8_t freq_table[256]);
+ *     - `freq_table` stores counts for all 256 possible values, with
+ *       two entries packed per byte. Only the first 128 bytes of the
+ *       array are required.
+ *     - Clamp each counter at 15 when incrementing.
+ *
+ * Optional Helper:
+ *   uint8_t get_frequency(uint8_t freq_table[], uint8_t value);
+ *     - Returns the stored frequency for the given value.
+ */

--- a/solutions/memory_efficient_frequency_tracker.c
+++ b/solutions/memory_efficient_frequency_tracker.c
@@ -1,0 +1,33 @@
+#include <stdint.h>
+#include <stddef.h>
+
+#define FREQ_TABLE_BYTES 128 /* 256 entries packed two per byte */
+
+/* Track frequencies of 8-bit readings with packed 4-bit counters */
+void track_frequencies(uint8_t readings[], int size, uint8_t freq_table[256])
+{
+    /* initialize only the needed bytes */
+    for (int i = 0; i < FREQ_TABLE_BYTES; ++i)
+        freq_table[i] = 0;
+
+    for (int i = 0; i < size; ++i) {
+        uint8_t val = readings[i];
+        int byte_index = val >> 1;      /* val / 2 */
+        int shift = (val & 1) << 2;     /* lower or upper nibble */
+
+        uint8_t count = (freq_table[byte_index] >> shift) & 0x0F;
+        if (count < 15) {
+            count++;
+            freq_table[byte_index] &= ~(0x0F << shift);
+            freq_table[byte_index] |= (count & 0x0F) << shift;
+        }
+    }
+}
+
+/* Retrieve frequency for a particular value */
+uint8_t get_frequency(uint8_t freq_table[], uint8_t value)
+{
+    int byte_index = value >> 1;
+    int shift = (value & 1) << 2;
+    return (freq_table[byte_index] >> shift) & 0x0F;
+}


### PR DESCRIPTION
## Summary
- add memory-efficient frequency tracker problem statement
- document notes on packed frequency table implementation
- implement compact 4-bit frequency tracking solution in C

## Testing
- `gcc -std=c99 -Wall -Wextra -pedantic -c solutions/memory_efficient_frequency_tracker.c`


------
https://chatgpt.com/codex/tasks/task_e_6885d45d10c08331a22e4c93eba275bb