### PR TITLE
Add packed GPIO pin configuration table example

### DIFF
--- a/notes/packed_gpio_pin_config_table_notes.txt
+++ b/notes/packed_gpio_pin_config_table_notes.txt
@@ -1,0 +1,16 @@
+Packed GPIO Pin Configuration Table Notes
+=========================================
+
+Each pin's mode is stored in two bits of a 64-bit register. To modify
+one pin:
+
+1. Create a mask `0x3ULL << (2 * pin)` covering its two bits.
+2. Clear those bits in the register using `&= ~mask`.
+3. OR the desired configuration (masked to 0x3) shifted into place.
+
+Reading a pin simply involves shifting right by `2 * pin` and masking
+with `0x3`.
+
+This design avoids additional memory and mirrors how microcontrollers
+pack configuration bits for GPIO pins.
+

--- a/problems/packed_gpio_pin_config_table.c
+++ b/problems/packed_gpio_pin_config_table.c
@@ -1,0 +1,25 @@
+/*
+ * Problem: Packed GPIO Pin Configuration Table
+ * -------------------------------------------
+ * A 32-pin GPIO controller stores each pin's mode in two bits:
+ *   00 = Input, 01 = Output, 10 = Alternate Function, 11 = Analog.
+ * Use a single 64-bit register to hold the configuration for all pins.
+ *
+ * Implement the following functions:
+ *   void set_pin_config(uint64_t *reg, int pin, uint8_t config);
+ *       - Set the configuration of 'pin' (0-31) to the value 'config' (0-3).
+ *   uint8_t get_pin_config(uint64_t reg, int pin);
+ *       - Return the current configuration of 'pin'.
+ *
+ * Bit Layout:
+ *   Pin 0 -> bits 1:0
+ *   Pin 1 -> bits 3:2
+ *   ...
+ *   Pin n -> bits (2*n+1):(2*n)
+ *
+ * Requirements:
+ *   - Only use the provided 64-bit register for storage.
+ *   - Clear the target bits before writing a new config.
+ *   - To read, shift right by 2*pin and mask with 0x3.
+ */
+

--- a/solutions/packed_gpio_pin_config_table.c
+++ b/solutions/packed_gpio_pin_config_table.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+
+/* Set the configuration of a single GPIO pin */
+void set_pin_config(uint64_t *reg, int pin, uint8_t config)
+{
+    if (pin < 0 || pin > 31)
+        return;
+
+    uint64_t mask = 0x3ULL << (pin * 2);
+    *reg &= ~mask;
+    *reg |= ((uint64_t)config & 0x3ULL) << (pin * 2);
+}
+
+/* Retrieve the configuration of a single GPIO pin */
+uint8_t get_pin_config(uint64_t reg, int pin)
+{
+    if (pin < 0 || pin > 31)
+        return 0;
+    return (reg >> (pin * 2)) & 0x3ULL;
+}
+


### PR DESCRIPTION
## Summary
- add problem statement for packed GPIO config table
- provide explanation notes on bit masking
- implement set/get pin config helpers

## Testing
- `gcc -std=c11 -Wall -Wextra -c solutions/packed_gpio_pin_config_table.c -o /tmp/test.o`

------
https://chatgpt.com/codex/tasks/task_e_68865eb930208331aad7327a5a158f08