### PR TITLE
Add packed peripheral config table problem and solution

### DIFF
--- a/notes/packed_peripheral_config_table_notes.txt
+++ b/notes/packed_peripheral_config_table_notes.txt
@@ -1,0 +1,11 @@
+Packed Peripheral Config Table Notes
+===================================
+
+The configuration table packs 16 peripherals using three bits each for a
+total of 48 bits. Because the array spans only six bytes, updating a
+single peripheral may require modifying bits across two adjacent bytes.
+
+The solution builds a 64-bit temporary variable from the array, updates
+the relevant 3-bit field, then writes the bytes back. This approach keeps
+the bit manipulations simple and avoids undefined behavior from shifting
+more than the width of a byte.

--- a/problems/packed_peripheral_config_table.c
+++ b/problems/packed_peripheral_config_table.c
@@ -1,0 +1,28 @@
+/*
+ * Problem: Packed Peripheral Config Table
+ * --------------------------------------
+ * Your embedded system has 16 hardware peripherals (SPI, I2C, CAN, UART, ...).
+ * Each peripheral stores its mode in a 3-bit field with the following meaning:
+ *   000 -> Disabled
+ *   001 -> Enabled
+ *   010 -> Sleep
+ *   011 -> Interrupt-Only
+ *   100-111 -> Reserved for future use
+ *
+ * All peripheral modes are packed into a single 6-byte array:
+ *   uint8_t config[6];
+ *   // 16 peripherals * 3 bits = 48 bits = 6 bytes
+ *
+ * Implement the following functions:
+ *   void set_peripheral_mode(uint8_t config[6], int index, uint8_t mode);
+ *       - Store 'mode' for peripheral 'index' (0-15). Only the lower
+ *         three bits of 'mode' are used.
+ *
+ *   uint8_t get_peripheral_mode(uint8_t config[6], int index);
+ *       - Retrieve the mode for peripheral 'index'.
+ *
+ * Constraints:
+ *   - No dynamic memory or structs; operate only on the 6-byte array.
+ *   - Bit packing must be tight (3 bits per peripheral) and may span bytes.
+ *   - Use bitwise operations to handle cross-byte reads and writes.
+ */

--- a/solutions/packed_peripheral_config_table.c
+++ b/solutions/packed_peripheral_config_table.c
@@ -1,0 +1,34 @@
+#include <stdint.h>
+
+/* Set the mode for a given peripheral */
+void set_peripheral_mode(uint8_t config[6], int index, uint8_t mode)
+{
+    if (index < 0 || index >= 16)
+        return;
+
+    uint64_t reg = 0;
+    for (int i = 0; i < 6; ++i)
+        reg |= ((uint64_t)config[i]) << (8 * i);
+
+    uint64_t shift = (uint64_t)(index * 3);
+    uint64_t mask = 0x7ULL << shift;
+
+    reg &= ~mask;
+    reg |= ((uint64_t)mode & 0x7ULL) << shift;
+
+    for (int i = 0; i < 6; ++i)
+        config[i] = (reg >> (8 * i)) & 0xFF;
+}
+
+/* Retrieve the mode for a given peripheral */
+uint8_t get_peripheral_mode(uint8_t config[6], int index)
+{
+    if (index < 0 || index >= 16)
+        return 0;
+
+    uint64_t reg = 0;
+    for (int i = 0; i < 6; ++i)
+        reg |= ((uint64_t)config[i]) << (8 * i);
+
+    return (reg >> (index * 3)) & 0x7ULL;
+}


### PR DESCRIPTION
## Summary
- add packed peripheral config table problem statement
- provide solution that packs 16 3-bit entries into six bytes
- document approach in developer notes

## Testing
- `gcc -std=c99 -Wall -Wextra -pedantic -c solutions/packed_peripheral_config_table.c`

------
https://chatgpt.com/codex/tasks/task_e_688a609af3708331bbc986f3e994d935