### PR TITLE
Add memory-constrained logger module

### DIFF
--- a/notes/memory_constrained_logger_notes.txt
+++ b/notes/memory_constrained_logger_notes.txt
@@ -1,0 +1,12 @@
+Memory-Constrained Logger System Notes
+=====================================
+
+The logger uses a static 1 KB memory pool to hold both log strings and
+metadata. Each log entry is stored exactly once in the pool and indexed
+by a 16-bit offset. Duplicates are detected through a linear search of
+previous entries.
+
+Retrieving logs in alphabetical order involves copying existing strings
+into a new array, sorting them with `qsort`, and returning the array to
+the caller. This keeps the persistent memory footprint below the 1 KB
+limit while allowing sorted retrieval on demand.

--- a/problems/memory_constrained_logger.c
+++ b/problems/memory_constrained_logger.c
@@ -1,0 +1,25 @@
+/*
+ * Problem: Memory-Constrained Logger System
+ * -----------------------------------------
+ * We need a logging module for a tiny embedded device with about 1 KB of RAM.
+ * Each log message is a short ASCII string up to 64 characters. Messages are
+ * inserted one at a time and duplicates must be ignored (only the first
+ * occurrence is kept). Logs are stored in insertion order but when requested
+ * should be returned in alphabetical order.
+ *
+ * Requirements:
+ *   - Ignore duplicate messages.
+ *   - Simulate a total RAM usage of roughly 1 KB for storage.
+ *   - At most 100 unique log messages will be stored.
+ *   - Implement the following functions:
+ *       void insert_log(const char *log_msg);
+ *       char **get_sorted_logs(int *num_logs);
+ *         -> Returns a dynamically allocated array of log strings sorted
+ *            alphabetically. The caller is responsible for freeing the
+ *            returned strings and the array itself.
+ *
+ * A simple brute-force approach is acceptable for this problem. For
+ * deduplication, a linear search of existing logs can be performed.
+ * When get_sorted_logs() is called, use qsort to sort copies of the
+ * stored strings.
+ */

--- a/solutions/memory_constrained_logger.c
+++ b/solutions/memory_constrained_logger.c
@@ -1,0 +1,87 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define POOL_SIZE 1024
+#define MAX_LOGS 100
+#define MAX_LOG_LENGTH 64
+
+/* static memory pool for all log messages */
+static char memory_pool[POOL_SIZE];
+static uint16_t offsets[MAX_LOGS];
+static uint8_t log_count = 0;
+static uint16_t pool_used = 0;
+
+/* duplicate of strdup for portability */
+static char *dup_string(const char *s)
+{
+    size_t len = strlen(s);
+    char *res = (char *)malloc(len + 1);
+    if (res)
+        memcpy(res, s, len + 1);
+    return res;
+}
+
+/* Insert a new log message if it is unique and space allows */
+void insert_log(const char *log_msg)
+{
+    if (!log_msg)
+        return;
+
+    /* Check for duplicates */
+    for (uint8_t i = 0; i < log_count; ++i) {
+        const char *stored = memory_pool + offsets[i];
+        if (strncmp(stored, log_msg, MAX_LOG_LENGTH) == 0) {
+            return; /* duplicate */
+        }
+    }
+
+    if (log_count >= MAX_LOGS)
+        return; /* capacity reached */
+
+    size_t len = 0;
+    while (len < MAX_LOG_LENGTH && log_msg[len] != '\0')
+        ++len;
+    if (pool_used + len + 1 > POOL_SIZE)
+        return; /* not enough simulated RAM */
+
+    memcpy(memory_pool + pool_used, log_msg, len);
+    memory_pool[pool_used + len] = '\0';
+    offsets[log_count++] = pool_used;
+    pool_used += len + 1;
+}
+
+static int cmp_strings(const void *a, const void *b)
+{
+    const char *sa = *(const char * const *)a;
+    const char *sb = *(const char * const *)b;
+    return strcmp(sa, sb);
+}
+
+/* Retrieve logs sorted alphabetically. Caller frees the result. */
+char **get_sorted_logs(int *num_logs)
+{
+    if (num_logs)
+        *num_logs = log_count;
+    if (log_count == 0)
+        return NULL;
+
+    char **arr = (char **)malloc(log_count * sizeof(char *));
+    if (!arr)
+        return NULL;
+
+    for (uint8_t i = 0; i < log_count; ++i) {
+        const char *msg = memory_pool + offsets[i];
+        arr[i] = dup_string(msg);
+        if (!arr[i]) {
+            /* cleanup on allocation failure */
+            for (uint8_t j = 0; j < i; ++j)
+                free(arr[j]);
+            free(arr);
+            return NULL;
+        }
+    }
+
+    qsort(arr, log_count, sizeof(char *), cmp_strings);
+    return arr;
+}


### PR DESCRIPTION
## Summary
- add new logging problem description
- provide implementation and developer notes for memory constrained logger

## Testing
- `gcc -std=c99 /tmp/logger_test.c -I. -o /tmp/logger_test && /tmp/logger_test`

------
https://chatgpt.com/codex/tasks/task_e_688bac2142b883318f1e6bc40b458ffd