### PR TITLE
Add GPIO event tracker bitset implementation

### DIFF
--- a/notes/gpio_event_tracker_notes.txt
+++ b/notes/gpio_event_tracker_notes.txt
@@ -1,0 +1,19 @@
+GPIO Event Tracker Notes
+=======================
+
+- A static array `uint32_t pins[8]` stores the state of 256 GPIO pins.
+  Each element represents 32 pins, giving a total of 32 bytes of storage.
+- Bit indexing:
+  - `pins[pin_id / 32]` selects the 32-bit word for a pin.
+  - `(pin_id % 32)` selects the bit within that word.
+
+Functions
+---------
+- `set_pin_active` and `set_pin_inactive` toggle the appropriate bit.
+- `is_pin_active` tests the bit and returns a boolean.
+- `count_active_pins` sums `__builtin_popcount` of each word.
+- `get_first_active_pin` (optional) finds the first non-zero word and uses
+  `__builtin_ctz` to locate the lowest set bit, avoiding a full 256-bit scan.
+
+This implementation meets the 32‑byte memory limit and requires no dynamic
+allocation.

--- a/problems/gpio_event_tracker.c
+++ b/problems/gpio_event_tracker.c
@@ -1,0 +1,25 @@
+/*
+ * Problem: GPIO Event Tracker (Memory-Efficient Bitset)
+ * -----------------------------------------------------
+ * You're designing a bitset-based event tracker for a microcontroller that
+ * monitors the state of 256 GPIO pins. Each pin can be either ACTIVE (1) or
+ * INACTIVE (0).
+ *
+ * Use only 32 bytes (256 bits) to store all pin statuses and implement the
+ * following operations using bit manipulation:
+ *
+ *   void set_pin_active(int pin_id);    // mark pin as active
+ *   void set_pin_inactive(int pin_id);  // mark pin as inactive
+ *   bool is_pin_active(int pin_id);     // check if a pin is active
+ *   int  count_active_pins();           // return the number of active pins
+ *
+ * Constraints:
+ *   - pin_id is in the range [0, 255]
+ *   - No dynamic memory allocation
+ *   - All operations must be implemented with bit operations
+ *
+ * Optional Extension:
+ *   int get_first_active_pin();
+ *     -> Return the lowest numbered active pin, or -1 if none. This should be
+ *        implemented without iterating over all 256 pins one by one.
+ */

--- a/solutions/gpio_event_tracker.c
+++ b/solutions/gpio_event_tracker.c
@@ -1,0 +1,45 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+/* 8 words x 32 bits = 256 bits -> 32 bytes */
+static uint32_t pin_bits[8];
+
+void set_pin_active(int pin_id)
+{
+    if (pin_id < 0 || pin_id >= 256)
+        return;
+    pin_bits[pin_id >> 5] |= (1u << (pin_id & 31));
+}
+
+void set_pin_inactive(int pin_id)
+{
+    if (pin_id < 0 || pin_id >= 256)
+        return;
+    pin_bits[pin_id >> 5] &= ~(1u << (pin_id & 31));
+}
+
+bool is_pin_active(int pin_id)
+{
+    if (pin_id < 0 || pin_id >= 256)
+        return false;
+    return (pin_bits[pin_id >> 5] >> (pin_id & 31)) & 1u;
+}
+
+int count_active_pins(void)
+{
+    int total = 0;
+    for (int i = 0; i < 8; ++i)
+        total += __builtin_popcount(pin_bits[i]);
+    return total;
+}
+
+int get_first_active_pin(void)
+{
+    for (int i = 0; i < 8; ++i) {
+        uint32_t word = pin_bits[i];
+        if (word != 0) {
+            return (i << 5) + __builtin_ctz(word);
+        }
+    }
+    return -1;
+}


### PR DESCRIPTION
## Summary
- add GPIO event tracker problem description
- document notes on approach
- implement memory-efficient bitset solution for GPIO pins

## Testing
- `gcc -std=c11 -Wall -Wextra -c solutions/gpio_event_tracker.c -o /tmp/gpio.o`

------
https://chatgpt.com/codex/tasks/task_e_688d0398aad88331a0a76a333bae07a8