### PR TITLE
Add compact sensor event tracker with wear leveling extension

### DIFF
--- a/notes/compact_sensor_event_tracker_notes.txt
+++ b/notes/compact_sensor_event_tracker_notes.txt
@@ -1,0 +1,11 @@
+Compact Sensor Event Tracker Notes
+=================================
+
+- Events are stored using two bits, allowing four logical values (0–3).
+- `insert_event` and `get_event` compute the target byte using `index >> 2`
+  and place the event at `(3 - (index & 3)) * 2` bits within that byte.
+- The 16-event extension uses four bits per event, storing two events per
+  byte with a similar shift calculation based on `index >> 1`.
+- Wear-leveling is simulated with per-byte modification counters. When a
+  counter exceeds `MAX_MODIFICATIONS` (10), a callback is invoked and the
+  counter resets, allowing the caller to relocate data and reduce flash wear.

--- a/problems/compact_sensor_event_tracker.c
+++ b/problems/compact_sensor_event_tracker.c
@@ -1,0 +1,43 @@
+/*
+ * Problem: Compact Sensor Event Tracker
+ * ------------------------------------
+ * You're developing firmware for a battery-powered IoT device that collects
+ * and logs sensor events. There are 8 types of events, each represented by an
+ * integer between 0 and 7.
+ *
+ * To save memory and reduce write operations to flash, the system stores
+ * multiple events in a compact format, using a single byte (8 bits) to store
+ * up to 4 events (2 bits per event).
+ *
+ * Design a compact event queue that:
+ *   - Can hold up to N sensor events, where N is divisible by 4.
+ *   - Uses the minimum number of bytes, storing 4 events per byte.
+ *   - Supports the following operations:
+ *       void insert_event(uint8_t *buffer, int index, uint8_t event);
+ *       uint8_t get_event(uint8_t *buffer, int index);
+ *
+ * Constraints:
+ *   - No dynamic memory allocation.
+ *   - Bitwise operations only (no memcpy, bitfields, etc.).
+ *   - Ensure byte writes do not affect neighboring events.
+ *
+ * Example:
+ *   uint8_t buffer[2]; // 8 events = 2 bytes
+ *   insert_event(buffer, 0, 1);
+ *   insert_event(buffer, 1, 2);
+ *   insert_event(buffer, 2, 3);
+ *   insert_event(buffer, 3, 0);
+ *   insert_event(buffer, 4, 2);
+ *   insert_event(buffer, 5, 1);
+ *   printf("%d", get_event(buffer, 2)); // Should return 3
+ *
+ * Follow-Up:
+ *   - Extend to support up to 16 event types using 4 bits (bitmask-aware logic).
+ *   - Add wear-leveling support: when a byte is modified more than 10 times,
+ *     trigger a callback to write it to a different memory location (simulate
+ *     this with a counter).
+ *
+ * Hint:
+ *   - Each event is 2 bits. For index i, it lies in byte i/4, and within that
+ *     byte its 2 bits are at shift: 6 - 2*(i%4).
+ */

--- a/solutions/compact_sensor_event_tracker.c
+++ b/solutions/compact_sensor_event_tracker.c
@@ -1,0 +1,71 @@
+#include <stdint.h>
+
+#define EVENT_BITS_2 2
+#define EVENT_MASK_2 0x3
+
+void insert_event(uint8_t *buffer, int index, uint8_t event)
+{
+    if (!buffer || index < 0 || event >= (1u << EVENT_BITS_2))
+        return;
+
+    int byte_index = index >> 2;                       /* index / 4 */
+    int shift = (3 - (index & 3)) * EVENT_BITS_2;      /* 6 - 2*(index % 4) */
+    buffer[byte_index] &= ~(EVENT_MASK_2 << shift);    /* clear existing bits */
+    buffer[byte_index] |= (event & EVENT_MASK_2) << shift; /* set new event */
+}
+
+uint8_t get_event(uint8_t *buffer, int index)
+{
+    if (!buffer || index < 0)
+        return 0;
+
+    int byte_index = index >> 2;
+    int shift = (3 - (index & 3)) * EVENT_BITS_2;
+    return (buffer[byte_index] >> shift) & EVENT_MASK_2;
+}
+
+#define EVENT_BITS_4 4
+#define EVENT_MASK_4 0xF
+#define MAX_MODIFICATIONS 10
+
+void insert_event16(uint8_t *buffer, int index, uint8_t event)
+{
+    if (!buffer || index < 0 || event >= (1u << EVENT_BITS_4))
+        return;
+
+    int byte_index = index >> 1;                       /* index / 2 */
+    int shift = (1 - (index & 1)) * EVENT_BITS_4;      /* 4 or 0 */
+    buffer[byte_index] &= ~(EVENT_MASK_4 << shift);
+    buffer[byte_index] |= (event & EVENT_MASK_4) << shift;
+}
+
+uint8_t get_event16(uint8_t *buffer, int index)
+{
+    if (!buffer || index < 0)
+        return 0;
+
+    int byte_index = index >> 1;
+    int shift = (1 - (index & 1)) * EVENT_BITS_4;
+    return (buffer[byte_index] >> shift) & EVENT_MASK_4;
+}
+
+void insert_event16_wl(uint8_t *buffer,
+                       uint8_t *mod_counts,
+                       int index,
+                       uint8_t event,
+                       void (*wear_callback)(int byte_index))
+{
+    if (!buffer || !mod_counts || index < 0 || event >= (1u << EVENT_BITS_4))
+        return;
+
+    int byte_index = index >> 1;
+    int shift = (1 - (index & 1)) * EVENT_BITS_4;
+    buffer[byte_index] &= ~(EVENT_MASK_4 << shift);
+    buffer[byte_index] |= (event & EVENT_MASK_4) << shift;
+
+    if (++mod_counts[byte_index] > MAX_MODIFICATIONS) {
+        if (wear_callback)
+            wear_callback(byte_index);
+        mod_counts[byte_index] = 0;
+    }
+}


### PR DESCRIPTION
## Summary
- add problem statement for compact sensor event tracker
- document bit-packing approach and wear leveling notes
- implement event insertion/retrieval for 2- and 4-bit events with wear leveling support

## Testing
- `gcc -std=c99 solutions/compact_sensor_event_tracker.c -c`


------
https://chatgpt.com/codex/tasks/task_e_6890e51be24c833194fbcd0a84faad35