### PR TITLE
Add memory-efficient unique sensor ID logger

### DIFF
--- a/notes/memory_efficient_unique_sensor_id_logger.txt
+++ b/notes/memory_efficient_unique_sensor_id_logger.txt
@@ -1,0 +1,35 @@
+Memory-Efficient Unique Sensor ID Logger
+=======================================
+
+Overview
+--------
+The logger keeps track of up to 512 distinct 32‑bit sensor IDs without any
+dynamic memory allocation.  IDs are stored directly in a fixed-size hash
+table that uses linear probing for collision resolution.  A companion array
+preserves the order in which unique IDs were first observed.
+
+Key Points
+----------
+* **Memory layout**
+  - `id_table[512]`: 32‑bit open-addressing hash table (2 KB).
+  - `order_index[512]`: indices into `id_table` recording insertion order
+    (~1 KB).
+* **Operations**
+  - `insert_sensor(id)`: O(1) expected time using multiplicative hash and
+    linear probing.  Duplicates simply return `false`.
+  - `reset_log()`: reinitializes the table and order count.
+  - `get_logged_ids(buf)`: copies unique IDs to `buf` preserving first-seen
+    order.
+* **Limitations & Assumptions**
+  - The sentinel value `0xFFFFFFFF` denotes an empty slot; this ID cannot be
+    logged.
+  - Table capacity is fixed; once 512 unique IDs are inserted, further
+    insertions fail.
+  - Maintaining insertion order requires additional RAM beyond the 2 KB
+    table.
+
+Potential Improvements
+----------------------
+* Compress the order-tracking structure using bit-packing to reduce RAM.
+* Use a different sentinel scheme if all 32‑bit values must be supported.
+* Extend the design with wear-leveling for persistent flash storage.

--- a/problems/memory_efficient_unique_sensor_id_logger.c
+++ b/problems/memory_efficient_unique_sensor_id_logger.c
@@ -1,0 +1,35 @@
+/*
+ * Problem: Memory-Efficient Unique Sensor ID Logger
+ * -----------------------------------------------
+ * In a memory constrained sensor node (4KB RAM), readings contain a
+ * 32-bit sensor ID. Duplicate readings from the same sensor are common
+ * due to noise or retransmission.
+ *
+ * Design a deduplicated logging system that:
+ *
+ *   - Stores only unique sensor IDs, keeping the order they first appear.
+ *   - Checks if an ID has been logged in O(1) time.
+ *   - Supports inserting new IDs and resetting the log.
+ *
+ * Requirements:
+ *   bool insert_sensor(uint32_t sensor_id);
+ *       - Returns true if the ID is new and stores it.
+ *       - Returns false if the ID was already logged.
+ *
+ *   void reset_log();
+ *       - Clears the memory for a new session.
+ *
+ * Constraints:
+ *   - No more than 2KB total memory for storage and lookup.
+ *   - Maximum of 512 unique IDs per session.
+ *   - No dynamic memory allocation (malloc, etc.).
+ *   - Target platform: bare-metal ARM Cortex-A.
+ *
+ * Bonus:
+ *   uint32_t get_logged_ids(uint32_t *output_buf);
+ *       - Dumps the stored unique IDs in insertion order into the
+ *         provided buffer. Returns the number of IDs copied.
+ *
+ * Consider future extensions such as minimizing writes to flash if the
+ * logger is made persistent.
+ */

--- a/solutions/memory_efficient_unique_sensor_id_logger.c
+++ b/solutions/memory_efficient_unique_sensor_id_logger.c
@@ -1,0 +1,52 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+#define MAX_IDS    512
+#define TABLE_SIZE 512
+#define EMPTY_SLOT 0xFFFFFFFFu
+
+static uint32_t id_table[TABLE_SIZE];
+static uint16_t order_index[MAX_IDS];
+static uint16_t id_count = 0;
+
+/* simple multiplicative hash, assumes TABLE_SIZE power of two */
+static inline uint32_t hash32(uint32_t x)
+{
+    return (x * 2654435761u) & (TABLE_SIZE - 1);
+}
+
+bool insert_sensor(uint32_t sensor_id)
+{
+    uint32_t idx = hash32(sensor_id);
+    for (uint32_t probe = 0; probe < TABLE_SIZE; ++probe) {
+        uint32_t pos = (idx + probe) & (TABLE_SIZE - 1);
+        uint32_t entry = id_table[pos];
+        if (entry == sensor_id) {
+            return false; /* already logged */
+        }
+        if (entry == EMPTY_SLOT) {
+            if (id_count >= MAX_IDS)
+                return false; /* table full */
+            id_table[pos] = sensor_id;
+            order_index[id_count++] = (uint16_t)pos;
+            return true;
+        }
+    }
+    return false; /* table full */
+}
+
+void reset_log(void)
+{
+    for (uint32_t i = 0; i < TABLE_SIZE; ++i)
+        id_table[i] = EMPTY_SLOT;
+    id_count = 0;
+}
+
+uint32_t get_logged_ids(uint32_t *output_buf)
+{
+    if (!output_buf)
+        return 0;
+    for (uint32_t i = 0; i < id_count; ++i)
+        output_buf[i] = id_table[order_index[i]];
+    return id_count;
+}


### PR DESCRIPTION
## Summary
- add problem description for memory-efficient unique sensor ID logger
- implement static hash-table based logger with O(1) lookups and ordered dump
- document design and limitations in developer notes

## Testing
- `gcc -std=c99 -Wall -Wextra -pedantic -c solutions/memory_efficient_unique_sensor_id_logger.c`


------
https://chatgpt.com/codex/tasks/task_e_68924a1e57648331a7533794eeae0549